### PR TITLE
Empty php function not working with not implemented isset magic method

### DIFF
--- a/data/OpenpayApiResourceBase.php
+++ b/data/OpenpayApiResourceBase.php
@@ -380,6 +380,13 @@ abstract class OpenpayApiResourceBase
         }
     }
 
+    public function __isset($key){
+        if (null === $this->__get($key)) {
+            return false;
+        }
+        return true;
+    }
+
 }
 
 ?>


### PR DESCRIPTION
Este fix es para el issue #45 , con esto debe funcionar el método empty() de PHP de forma correcta.

Fuentes:

https://edmondscommerce.github.io/php/php-__get-and-empty-not-working-as-you-expect-solution.html

https://www.php.net/manual/en/function.empty.php