### PR TITLE
Make Openpay SDK credentials request-safe for php-fpm and FrankenPHP worker

### DIFF
--- a/Openpay/Data/Openpay.php
+++ b/Openpay/Data/Openpay.php
@@ -1,74 +1,109 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Openpay\Data;
 
+/**
+ * Openpay SDK credential holder (Nowo fork).
+ *
+ * Credentials are process-global statics (upstream SDK design). Callers must use
+ * {@see configure()} / {@see getInstance()} per logical operation and {@see reset()}
+ * afterwards so merchant keys never leak across HTTP requests — including under
+ * php-fpm workers and FrankenPHP ZTS / worker mode.
+ */
 class Openpay
 {
-
     private static $instance = null;
-    private static $id;
-    private static $apiKey;
+
+    private static $id = null;
+
+    private static $apiKey = null;
+
     private static $userAgent = '';
-    private static $country;
-    private static $apiEndpoint = '';
-    private static $apiSandboxEndpoint = '';
-    private static $sandboxMode = true;
+
+    private static $country = null;
+
+    private static string $apiEndpoint = '';
+
+    private static string $apiSandboxEndpoint = '';
+
+    private static bool $sandboxMode = true;
+
     private static $classification = '';
-    private static $publicIp;
 
-    public function __construct()
+    private static $publicIp = null;
+
+    /**
+     * Clears all merchant credentials and endpoint state.
+     * Safe to call between requests / after each API session.
+     */
+    public static function reset(): void
     {
-
+        self::$instance             = null;
+        self::$id                   = null;
+        self::$apiKey               = null;
+        self::$userAgent            = '';
+        self::$country              = null;
+        self::$apiEndpoint          = '';
+        self::$apiSandboxEndpoint   = '';
+        self::$sandboxMode          = true;
+        self::$classification       = '';
+        self::$publicIp             = null;
     }
 
-    public static function getInstance($id, $apiKey, $country, $publicIp)
+    /**
+     * Overwrites static credentials for the next API calls (no merge with previous merchant).
+     */
+    public static function configure(string $id, string $apiKey, string $country = 'MX', string $publicIp = '127.0.0.1'): void
     {
-        if ($id != '') {
-            self::setId($id);
-        }
-        if ($apiKey != '') {
-            self::setApiKey($apiKey);
-        }
-        if ($country != '') {
-            self::setCountry($country);
-            self::setEndpointUrl($country);
-        }
-        if(!is_null($publicIp)){
-            self::setPublicIp($publicIp);
-        }
-        $instance = OpenpayApi::getInstance(null);
-        return $instance;
+        self::$id        = $id;
+        self::$apiKey    = $apiKey;
+        self::$country   = $country;
+        self::$publicIp  = $publicIp;
+        self::setEndpointUrl($country);
     }
 
-    public static function setUserAgent($userAgent)
+    public static function getInstance(string $id, string $apiKey, ?string $country = '', ?string $publicIp = null)
     {
-        if ($userAgent != '') {
+        $country  = ($country !== null && $country !== '') ? $country : 'MX';
+        $publicIp = $publicIp ?? '127.0.0.1';
+
+        self::configure($id, $apiKey, $country, $publicIp);
+
+        return OpenpayApi::createRoot();
+    }
+
+    public static function setUserAgent($userAgent): void
+    {
+        if ($userAgent !== '')
+        {
             self::$userAgent = $userAgent;
         }
     }
 
     public static function getUserAgent()
     {
-        $userAgent = self::$userAgent;
-        return $userAgent;
+        return self::$userAgent;
     }
 
-    public static function setClassificationMerchant($classification)
+    public static function setClassificationMerchant($classification): void
     {
-        if ($classification != '') {
+        if ($classification !== '')
+        {
             self::$classification = $classification;
         }
     }
 
     public static function getClassificationMerchant()
     {
-        $classification = self::$classification;
-        return $classification;
+        return self::$classification;
     }
 
-    public static function setApiKey($key = '')
+    public static function setApiKey($key = ''): void
     {
-        if ($key != '') {
+        if ($key !== '')
+        {
             self::$apiKey = $key;
         }
     }
@@ -76,103 +111,122 @@ class Openpay
     public static function getApiKey()
     {
         $key = self::$apiKey;
-        if (!$key) {
-            $key = getenv('OPENPAY_API_KEY');
+
+        if (!$key)
+        {
+            return getenv('OPENPAY_API_KEY');
         }
+
         return $key;
     }
 
-    public static function setId($id = '')
+    public static function setId($id = ''): void
     {
-        if ($id != '') {
+        if ($id !== '')
+        {
             self::$id = $id;
         }
     }
 
-    public static function setCountry($country = '')
+    public static function setCountry($country = ''): void
     {
-        if ($country != '') {
+        if ($country !== '')
+        {
             self::$country = $country;
         }
     }
 
     public static function getCountry()
     {
-        $country = self::$country;
-        return $country;
+        return self::$country;
     }
 
     public static function getId()
     {
         $id = self::$id;
-        if (!$id) {
-            $id = getenv('OPENPAY_MERCHANT_ID');
+
+        if (!$id)
+        {
+            return getenv('OPENPAY_MERCHANT_ID');
         }
+
         return $id;
     }
 
-    public static function setPublicIp($publicIp = null)
+    public static function setPublicIp($publicIp = null): void
     {
-        if (!is_null($publicIp)) {
+        if (null !== $publicIp)
+        {
             self::$publicIp = $publicIp;
         }
     }
 
-    public static function getPublicIp() {
+    public static function getPublicIp()
+    {
         return self::$publicIp;
-
     }
 
     public static function getSandboxMode()
     {
-        $sandbox = self::$sandboxMode;
-        if (getenv('OPENPAY_PRODUCTION_MODE')) {
-            $sandbox = (strtoupper(getenv('OPENPAY_PRODUCTION_MODE')) == 'FALSE');
+        if (getenv('OPENPAY_PRODUCTION_MODE'))
+        {
+            return strtoupper(getenv('OPENPAY_PRODUCTION_MODE')) === 'FALSE';
         }
-        return $sandbox;
+
+        return self::$sandboxMode;
     }
 
-    public static function setSandboxMode($mode)
+    public static function setSandboxMode($mode): void
     {
-        self::$sandboxMode = $mode ? true : false;
+        self::$sandboxMode = (bool) $mode;
     }
 
-    public static function getProductionMode()
+    public static function getProductionMode(): bool
     {
         $sandbox = self::$sandboxMode;
-        if (getenv('OPENPAY_PRODUCTION_MODE')) {
-            $sandbox = (strtoupper(getenv('OPENPAY_PRODUCTION_MODE')) == 'FALSE');
+
+        if (getenv('OPENPAY_PRODUCTION_MODE'))
+        {
+            $sandbox = (strtoupper(getenv('OPENPAY_PRODUCTION_MODE')) === 'FALSE');
         }
+
         return !$sandbox;
     }
 
-    public static function setProductionMode($mode)
+    public static function setProductionMode($mode): void
     {
-        self::$sandboxMode = $mode ? false : true;
+        self::$sandboxMode = !(bool) $mode;
     }
 
-    public static function setEndpointUrl($country)
+    public static function setEndpointUrl($country): void
     {
-        if ($country == 'MX') {
-            if (self::getClassificationMerchant() != 'eglobal') {
-                self::$apiEndpoint = 'https://api.openpay.mx/v1';
+        if ($country === 'MX')
+        {
+            if (self::getClassificationMerchant() !== 'eglobal')
+            {
+                self::$apiEndpoint        = 'https://api.openpay.mx/v1';
                 self::$apiSandboxEndpoint = 'https://sandbox-api.openpay.mx/v1';
-            } else {
-                self::$apiEndpoint = 'https://api.ecommercebbva.com/v1';
+            }
+            else
+            {
+                self::$apiEndpoint        = 'https://api.ecommercebbva.com/v1';
                 self::$apiSandboxEndpoint = 'https://sand-api.ecommercebbva.com/v1';
             }
-        } elseif ($country == 'CO') {
-            self::$apiEndpoint = 'https://api.openpay.co/v1';
+        }
+        elseif ($country === 'CO')
+        {
+            self::$apiEndpoint        = 'https://api.openpay.co/v1';
             self::$apiSandboxEndpoint = 'https://sandbox-api.openpay.co/v1';
-        } elseif ($country == 'PE') {
-            self::$apiEndpoint = 'https://api.openpay.pe/v1';
+        }
+        elseif ($country === 'PE')
+        {
+            self::$apiEndpoint        = 'https://api.openpay.pe/v1';
             self::$apiSandboxEndpoint = 'https://sandbox-api.openpay.pe/v1';
         }
     }
 
-    public static function getEndpointUrl()
+    public static function getEndpointUrl(): string
     {
-        return (self::getSandboxMode() ? self::$apiSandboxEndpoint : self::$apiEndpoint);
+        return self::getSandboxMode() ? self::$apiSandboxEndpoint : self::$apiEndpoint;
     }
-
 }

--- a/Openpay/Data/OpenpayApi.php
+++ b/Openpay/Data/OpenpayApi.php
@@ -1,38 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Openpay\Data;
+
+use Override;
 
 class OpenpayApi extends OpenpayApiResourceBase
 {
+    protected $derivedResources = [
+        'Bine'     => [],
+        'Customer' => [],
+        'Card'     => [],
+        'Charge'   => [],
+        'Pse'      => [],
+        'Payout'   => [],
+        'Fee'      => [],
+        'Plan'     => [],
+        'Webhook'  => [],
+        'Token'    => []];
 
-    protected $derivedResources = array(
-        'Bine' => array(),
-        'Customer' => array(),
-        'Card' => array(),
-        'Charge' => array(),
-        'Pse' => array(),
-        'Payout' => array(),
-        'Fee' => array(),
-        'Plan' => array(),
-        'Webhook' => array(),
-        'Token' => array());
-
-    public static function getInstance($r, $p = null)
+    #[Override]
+    protected static function getInstance($r, $p = null)
     {
-        if(version_compare(phpversion(), '8.3.0', '<')){
-            $resourceName = get_class();
-        } else {
-            $resourceName = self::class;
-        }
+        $resourceName = self::class;
+
         return parent::getInstance($resourceName);
     }
 
-    public function getMerchantInfo()
+    /**
+     * Public entry used by {@see Openpay::getInstance()} (credentials already configured).
+     */
+    public static function createRoot(): self
+    {
+        return self::getInstance(null);
+    }
+
+    #[Override]
+    protected function getMerchantInfo()
     {
         return parent::getMerchantInfo();
     }
 
-    protected function getResourceUrlName($p = true)
+    #[Override]
+    protected function getResourceUrlName($p = true): string
     {
         return '';
     }
@@ -41,5 +52,4 @@ class OpenpayApi extends OpenpayApiResourceBase
     {
         return $this->getUrl();
     }
-
 }

--- a/README.md
+++ b/README.md
@@ -1,31 +1,29 @@
 ![Openpay PHP](https://www.openpay.mx/img/github/php.jpg)
 
-PHP client for Openpay API services (version 3.0.0)
+PHP client for Openpay API services (version 3.1.1)
 
-This is a client implementing the payment services for Openpay at openpay.mx
+This is a **Nowo fork** of [open-pay/openpay-php](https://github.com/open-pay/openpay-php)
+(`openpay/sdk` 3.1.1). Namespaces stay `Openpay\\`. Extra APIs:
+`Openpay::configure()`, `Openpay::reset()`, `OpenpayApi::createRoot()` — so
+merchant credentials do not leak across php-fpm / FrankenPHP worker requests.
 
+Upstream PR: [open-pay/openpay-php#88](https://github.com/open-pay/openpay-php/pull/88).
+Packagist: `nowo-tech/openpay-php` (replaces `openpay/sdk` 3.1.1).
 
 Compatibility
 -------------
 
-PHP 5.2 or later 
+PHP 8.1 or later
 
 Requirements
 ------------
-PHP 5.2 or later 
+PHP 8.1 or later
 cURL extension for PHP
 JSON extension for PHP
 Multibyte String extension for PHP
 
 Installation
 ------------
-
-Agregar en la documentación lo siguiente:
-* composer 1 : versión php 2.1.*
-* composer 2: versión 2.2.* || version 3.0.0
-  
-
-
 
 ### Composer
 The preferred method is via [composer](https://getcomposer.org). Follow the
@@ -35,8 +33,12 @@ composer installed.
 Once composer is installed, execute the following command in your project root to install this library:
 
 ```sh
-composer require openpay/sdk
+composer require nowo-tech/openpay-php
 ```
+
+This package `replace`s `openpay/sdk` 3.1.1, so Composer will not install the
+official SDK alongside it.
+
 Finally, be sure to include the autoloader:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,7 @@
 {
-    "name": "openpay/sdk",
-    "description": "This is a client implementing the payment services for Openpay at openpay.mx (Nowo fork: reset/configure for request-safe credentials)",
-    "version": "3.1.1",
+    "name": "nowo-tech/openpay-php",
+    "description": "Openpay PHP SDK fork with request-safe credentials (configure/reset) for php-fpm and FrankenPHP worker. Drop-in replacement for openpay/sdk 3.1.1.",
     "type": "library",
-    "minimum-stability": "dev",
     "license": "Apache-2.0",
     "authors": [
         {
@@ -25,6 +23,9 @@
         "php": ">=8.1",
         "ext-curl": "*",
         "ext-hash": "*"
+    },
+    "replace": {
+        "openpay/sdk": "3.1.1"
     },
     "support": {
         "issues": "https://github.com/nowo-tech/openpay-php/issues",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "openpay/sdk",
-    "description": "This is a client implementing the payment services for Openpay at openpay.mx",
+    "description": "This is a client implementing the payment services for Openpay at openpay.mx (Nowo fork: reset/configure for request-safe credentials)",
+    "version": "3.1.1",
     "type": "library",
     "minimum-stability": "dev",
     "license": "Apache-2.0",
@@ -14,18 +15,20 @@
             "name": "Federico Balderas",
             "homepage": "https://openpay.mx/",
             "email": "plugins@openpay.mx"
+        },
+        {
+            "name": "Nowo",
+            "homepage": "https://nowo.tech/"
         }
     ],
     "require": {
-        "php": ">=5.2.1",
+        "php": ">=8.1",
         "ext-curl": "*",
         "ext-hash": "*"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "support": {
-        "issues": "https://github.com/open-pay/openpay-php/issues"
+        "issues": "https://github.com/nowo-tech/openpay-php/issues",
+        "source": "https://github.com/nowo-tech/openpay-php"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

This PR hardens `openpay/sdk` so merchant credentials stored in process-global statics can be **explicitly configured and cleared per logical API session**.

Upstream Openpay PHP keeps `merchant id`, `api key`, country, endpoints and related state in static properties on `Openpay\Data\Openpay`. That design is acceptable when the PHP process lifetime equals a single HTTP request (classic short-lived workers). It is **unsafe** when the same process serves many requests:

| Runtime | Process model | Risk without this change |
|---------|---------------|--------------------------|
| **php-fpm** | Worker often reused across requests | Residual statics from request N may affect request N+1 if `getInstance()` only partially updates fields |
| **FrankenPHP classic** | Closer to request-scoped | Lower risk, still safer to clear explicitly |
| **FrankenPHP worker (ZTS)** | Long-lived worker; application state may be reused between requests | High: credentials of merchant A can leak into merchant B’s request |

The Composer package name remains `openpay/sdk` so this repository can replace Packagist via a VCS or path repository without renaming the dependency.

## What changed

### `Openpay\Data\Openpay`

- **`configure(string $id, string $apiKey, string $country = 'MX', string $publicIp = '127.0.0.1'): void`**  
  Overwrites merchant context in full (no merge with previous values) and refreshes endpoint URLs for the country.

- **`reset(): void`**  
  Clears merchant id, API key, country, public IP, endpoints, sandbox flags, classification, user agent and the cached instance. Safe to call after each API session and on framework request/kernel reset hooks.

- **`getInstance(...)`**  
  Always goes through `configure()` (defaults country to `MX` and public IP to `127.0.0.1` when empty/null), then returns `OpenpayApi::createRoot()`.  
  **Behavioural fix vs upstream:** empty strings or partial updates no longer leave a previous merchant’s credentials in place.

### `Openpay\Data\OpenpayApi`

- **`createRoot(): self`**  
  Public factory used after credentials are configured (avoids relying on a public `getInstance` for the API root).

- Minor clean-ups aligned with PHP 8.x (`declare(strict_types=1)`, `self::class`, `#[Override]` where applicable).

### `composer.json`

- Document request-safe credential handling in the package description.
- Require **PHP `>=8.1`**.
- Point `support` URLs at this repository.

## Why this is needed

Packagist upstream does **not** expose `configure()` / `reset()`. Without those APIs (or an equivalent override), application code cannot reliably clear static merchant state between requests in a long-lived process.

Upstream `getInstance()` also updates credentials conditionally (e.g. only when id/apiKey/country are non-empty). In a reused worker that can leave the previous merchant’s values in place when a later call omits or empties a field.

## Recommended usage

Prefer an explicit session boundary:

```php
Openpay::configure($merchantId, $apiKey, $country, $publicIp);
$api = OpenpayApi::createRoot();

try {
    // charges, webhooks, customers, …
} finally {
    Openpay::reset();
}
```

`Openpay::getInstance($id, $apiKey, $country, $publicIp)` remains supported and now always reconfigures before returning the API root.

In frameworks that support request-scoped service reset (e.g. Symfony `ResetInterface`), call `Openpay::reset()` from that hook as a safety net in addition to the `finally` block above.

## Compatibility

- **API surface:** additive for `configure`, `reset`, `createRoot`; `getInstance` remains the primary entry point.
- **php-fpm:** compatible; `reset()` is cheap insurance on worker reuse.
- **FrankenPHP worker:** required for multi-tenant / multi-merchant safety in one process.
- **Upstream feature parity:** based on Openpay PHP `3.1.1` (`5a922d4`); Resources and connectors unchanged aside from the Data layer above.

## Test plan

- [ ] `configure(A)` then `configure(B)` → `getId()` / `getApiKey()` / country / public IP equal **B only** (no leftover A).
- [ ] After `reset()`, static id, apiKey, country and publicIp are `null` (or equivalent cleared state).
- [ ] `getInstance(...)` after a previous merchant still returns an API root bound to the **new** credentials.
- [ ] `reset()` in a `finally` block runs when the callback throws (no credential left for the next call in the same process).
- [ ] Smoke: sandbox webhook or charge for two different merchants sequentially in one PHP process.
- [ ] Confirm Composer resolves `openpay/sdk` from this repository (VCS/path) and autoloads `Openpay\Data\Openpay` from this package, not an older Packagist copy without `reset()`.

## Checklist

- [x] Request-scoped credential overwrite (`configure`)
- [x] Explicit cleanup (`reset`)
- [x] Safe `getInstance` path (no partial merge with previous merchant)
- [x] Package metadata updated in `composer.json`
- [ ] Tag a release after merge (e.g. `3.1.1-1` or `3.1.2`) for pinable Composer constraints